### PR TITLE
Fix Railway deployment by removing Nixpacks builder config

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,6 +1,3 @@
-[build]
-builder = "NIXPACKS"
-
 [deploy]
 startCommand = "npm start"
 restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
Railway will now auto-detect Node.js and use the default build process instead of failing with the problematic Nixpacks configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)