### PR TITLE
Force Railway to use Dockerfile instead of Nixpacks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/railway.toml
+++ b/railway.toml
@@ -1,3 +1,6 @@
+[build]
+builder = "DOCKERFILE"
+
 [deploy]
 startCommand = "npm start"
 restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
Added explicit Dockerfile configuration to bypass Railway's cached Nixpacks detection that was causing build failures.

🤖 Generated with [Claude Code](https://claude.ai/code)